### PR TITLE
add: 공통 버튼 컴포넌트 생성

### DIFF
--- a/src/app/_components/common/Button.tsx
+++ b/src/app/_components/common/Button.tsx
@@ -1,0 +1,39 @@
+type Color = 'default' | 'white' | 'red';
+type Size = 'sm' | 'md' | 'full';
+type Type = 'button' | 'submit';
+
+interface ButtonType {
+  children: React.ReactNode;
+  onClick: () => void;
+  color?: Color;
+  size?: Size;
+  type?: Type;
+}
+
+const buttonTheme = {
+  color: {
+    default: 'text-white bg-green-400 border-green-400',
+    white: 'text-green-400 bg-white border-green-400',
+    red: 'text-red-400 bg-white border-red-400'
+  },
+
+  size: {
+    sm: 'px-2 py-1.5 text-sm',
+    md: 'px-3 py-2 text-base',
+    full: 'py-3 w-full text-base'
+  }
+};
+
+const Button = ({ children, onClick, color = 'default', size = 'md', type = 'button' }: ButtonType) => {
+  return (
+    <button
+      className={`${buttonTheme.color[color]} ${buttonTheme.size[size]} text-center rounded-md font-semibold border`}
+      onClick={onClick}
+      type={type}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/app/commontest/page.tsx
+++ b/src/app/commontest/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Button from '../_components/common/Button';
+
+const CommonComponentsTestPage = () => {
+  const testOnclickHandler = () => console.log('test!');
+  return (
+    <div className="flex flex-col gap-[10px] px-[20px]">
+      <h1>공통 컴포넌트 테스트 페이지</h1>
+      <a href="https://msm1307.tistory.com/156" className="text-[30px] text-[#8793ff]">
+        버튼 관련 자료 블로그 링크(클릭시 이동)
+      </a>
+      <div className="flex flex-row gap-[20px] flex-wrap">
+        <Button onClick={testOnclickHandler}>default컬러, md크기</Button>
+        <Button onClick={testOnclickHandler} color="default" size="md">
+          default컬러, md크기
+        </Button>
+        <Button onClick={testOnclickHandler} color="white" size="sm">
+          white컬러, sm크기
+        </Button>
+        <Button onClick={testOnclickHandler} color="white" size="full">
+          white컬러, full크기
+        </Button>
+        <Button onClick={testOnclickHandler} color="red" size="full">
+          red컬러, full크기
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default CommonComponentsTestPage;


### PR DESCRIPTION
## ✅ 작업 사항
- 공통 버튼 컴포넌트 생성

## 📌 변경 사항
- 공통 버튼 컴포넌트 생성 및 테마 추가
- 공통 컴포넌트들을 확인할 수 있는 commontest 페이지 추가(배포시 삭제필요)
![image](https://github.com/user-attachments/assets/8cab0380-e7be-4217-9bb7-89b5eca8ba47)
![image](https://github.com/user-attachments/assets/e238a43f-b2c6-4942-9973-9b36e26a99c3)
![image](https://github.com/user-attachments/assets/5fa6bb21-4959-4cd4-b689-20cd8cd6c9da)

## 🧑‍💻 기타
- 스타일 템플릿을 추가하고 싶을때는 buttonTheme객체에 추가하고, 타입도 추가해야합니다.
![image](https://github.com/user-attachments/assets/5bd70536-2ded-4fbb-9623-d10886077931)

- 만약 테마를 추가했을 시 다른 팀원들을 위해 해당 테마의 버튼을 공통컴포넌트 테스트 페이지에 추가해주세요! /commontest/page.tsx
![image](https://github.com/user-attachments/assets/69d8cbf0-1757-49fc-8cc6-7e7f65b8a300)
