### PR TITLE
refactor: resumeadd페이지 로직분리/컴포넌트분리

### DIFF
--- a/src/app/(resume)/resumeadd/page.tsx
+++ b/src/app/(resume)/resumeadd/page.tsx
@@ -4,13 +4,34 @@ import Button from '@/app/_components/common/Button';
 import Input from '@/app/_components/common/Input';
 import { EMPTY_EDU_OBJ, EMPTY_EXP_OBJ, EMPTY_LIC_OBJ } from '@/constants/resumeConstants';
 import useInput from '@/hooks/useInput';
-import { EducationType, ExperienceType, LicenseType } from '@/types/ResumeType';
 import browserClient from '@/utils/supabase/client';
 import React, { useEffect, useRef, useState } from 'react';
-import jsPDF from 'jspdf';
 import '@/utils/resume/malgun-normal.js';
-import { convertImgToBase64 } from '@/utils/resume/convertImgToBase64';
 import SideBarByPage from '@/app/_components/common/SideBarByPage';
+import { updatePdfToStorage, uploadPdfToStorage } from '@/utils/resume/client-actions';
+import {
+  getPostDetail,
+  getUserPoint,
+  updateResumeData,
+  updateTransformedData,
+  uploadResumeData,
+  uploadTransformedData
+} from '@/utils/resume/server-action';
+import { makeResumePdf } from '@/utils/resume/makeResumePdf';
+import { transformResumeData } from '@/services/resumeadd/resumeaddServices';
+import { EducationType, EduFormType, ExperienceType, ExpFormType, LicenseType, LicFormType } from '@/type/resumeTypes';
+import ProfileImgLabel from '@/app/_components/resumeadd/ProfileImgLabel';
+import EducationBox from '@/app/_components/resumeadd/EducationBox';
+import ExperienceBox from '@/app/_components/resumeadd/ExperienceBox';
+import LicenseBox from '@/app/_components/resumeadd/LicenseBox';
+import useResumeAddpage from '@/hooks/useResumeAddpage';
+import SideBarItem from '@/app/_components/resumeadd/SideBarItem';
+import ResumeTopSection from '@/app/_components/resumeadd/ResumeTopSection';
+import PersonalDataSection from '@/app/_components/resumeadd/PersonalDataSection';
+import EducationSection from '@/app/_components/resumeadd/EducationSection';
+import ExperienceSection from '@/app/_components/resumeadd/ExperienceSection';
+import LicenseSection from '@/app/_components/resumeadd/LicenseSection';
+import ResumeDescSection from '@/app/_components/resumeadd/ResumeDescSection';
 interface Props {
   searchParams: {
     query_post_id?: string;
@@ -18,45 +39,64 @@ interface Props {
 }
 
 const ResumeAddPage = ({ searchParams: { query_post_id } }: Props) => {
-  query_post_id && console.log('props :>> ', query_post_id);
-  const [title, handleTitle, titleRef, setTitle] = useInput('');
-  const [name, handleName, nameRef, setName] = useInput('');
-  const [gender, handleGender, genderRef, setGender] = useInput('');
-  const [phoneNum, handlePhoneNum, phoneNumRef, setPhoneNum] = useInput('');
-  const [email, handleEmail, emailRef, setEmail] = useInput('');
-  const [address, handleAddress, addressRef, setAddress] = useInput('');
-  const [region, handleRegion, regionRef, setRegion] = useInput('');
-  const [expYears, handleExpYears, expYearsRef, setExpYears] = useInput(0);
-  const [resumeDesc, handleResumeDesc, _, setResumeDesc] = useInput('');
-  const resumeDescRef = useRef<HTMLTextAreaElement>(null);
-  const [point, handlePoint, pointRef, setPoint] = useInput(0);
-  const [profileImg, setProfileImg] = useState<File>();
-  const [postId, setPostId] = useState(crypto.randomUUID());
-  const handleProfileImg = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const targetFile = e.target.files && e.target.files[0];
-    if (targetFile) {
-      if (targetFile.type !== 'image/png') {
-        alert('png 이미지만 첨부 가능합니다.');
-        return;
-      } else {
-        setProfileImg(targetFile);
-      }
-    } else {
-      alert('파일을 업로드 해주세요!');
-      return;
-    }
-  };
-
-  const [eduArray, setEduArray] = useState<EducationType[]>([]);
-  const [expArray, setExpArray] = useState<ExperienceType[]>([]);
-  const [licArray, setLicArray] = useState<LicenseType[]>([]);
-
-  const [userId, setUserId] = useState('');
-  const [resume_url, setResume_url] = useState('');
-  const [portfolio_url, setPortfolio_url] = useState('');
-  // const [use_point, setUse_point] = useState(0);
-  const [isadopted, setIsadopted] = useState(false);
-
+  const {
+    openNewTabForPdf,
+    handleUploadPdf,
+    savePdfToLocal,
+    point,
+    handlePoint,
+    pointRef,
+    title,
+    handleTitle,
+    titleRef,
+    profileImg,
+    handleProfileImg,
+    expYears,
+    handleExpYears,
+    expYearsRef,
+    name,
+    handleName,
+    nameRef,
+    gender,
+    handleGender,
+    genderRef,
+    email,
+    handleEmail,
+    emailRef,
+    phoneNum,
+    handlePhoneNum,
+    phoneNumRef,
+    region,
+    handleRegion,
+    regionRef,
+    address,
+    handleAddress,
+    addressRef,
+    addForm,
+    eduArray,
+    deleteForm,
+    expArray,
+    licArray,
+    resumeDesc,
+    handleResumeDesc,
+    resumeDescRef,
+    setUserId,
+    setTitle,
+    setName,
+    setGender,
+    setPhoneNum,
+    setEmail,
+    setAddress,
+    setRegion,
+    setExpYears,
+    setResumeDesc,
+    setPoint,
+    setPostId,
+    setIsadopted,
+    setEduArray,
+    setExpArray,
+    setLicArray
+  } = useResumeAddpage();
   useEffect(() => {
     const getUserId = async () => {
       const { data: userSession, error: userSessionError } = await browserClient.auth.getSession();
@@ -68,29 +108,20 @@ const ResumeAddPage = ({ searchParams: { query_post_id } }: Props) => {
     };
     getUserId();
     const getPostData = async () => {
-      const { data: postData, error: postDataError } = await browserClient
-        .from('post_detail')
-        .select(
-          '*, eduArray:post_detail_education(*), expArray:post_detail_experience(*), licArray:post_detail_license(*)'
-        )
-        .eq('post_id', query_post_id);
+      const { data: postData, error: postDataError } = await getPostDetail(query_post_id as string);
       if (postDataError) {
         console.log('postDataError :>> ', postDataError);
         return;
-      } else {
+      } else if (postData) {
         const {
           eduArray,
           expArray,
           licArray,
-          user_uuid,
           post_id,
-          use_point,
           isadopted,
           experience,
           region,
           post_title,
-          resume_url,
-          portfolio_url,
           post_desc,
           name,
           gender,
@@ -110,131 +141,14 @@ const ResumeAddPage = ({ searchParams: { query_post_id } }: Props) => {
         setResumeDesc(post_desc);
         setPoint(point);
         setPostId(post_id);
-        setResume_url(resume_url);
-        setPortfolio_url(portfolio_url);
-        // setUse_point(use_point);
         setIsadopted(isadopted);
         setEduArray(eduArray);
         setExpArray(expArray);
         setLicArray(licArray);
       }
     };
-    query_post_id && getPostData();
+    !!query_post_id && getPostData();
   }, []);
-
-  const handleArray = <T,>(
-    idx: number,
-    name: string,
-    setState: React.Dispatch<React.SetStateAction<T[]>>,
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    setState((prev) => {
-      const changedArray = [...prev];
-      changedArray[idx] = {
-        ...changedArray[idx],
-        [name]: e.target.value
-      };
-      return changedArray;
-    });
-  };
-
-  const addForm = (objName: string) => {
-    switch (objName) {
-      case 'education':
-        setEduArray((prev) => [...prev, { ...EMPTY_EDU_OBJ, edu_id: crypto.randomUUID() }]);
-        break;
-      case 'experience':
-        setExpArray((prev) => [...prev, { ...EMPTY_EXP_OBJ, exp_id: crypto.randomUUID() }]);
-        break;
-      case 'license':
-        setLicArray((prev) => [...prev, { ...EMPTY_LIC_OBJ, lic_id: crypto.randomUUID() }]);
-        break;
-    }
-  };
-  const deleteForm = (objName: string, id: string) => {
-    switch (objName) {
-      case 'education':
-        setEduArray((prev) => prev.filter((edu) => edu.edu_id !== id));
-        break;
-      case 'experience':
-        setExpArray((prev) => prev.filter((exp) => exp.exp_id !== id));
-        break;
-      case 'license':
-        setLicArray((prev) => prev.filter((lic) => lic.lic_id !== id));
-        break;
-    }
-  };
-
-  const makeResumePdf = async () => {
-    const doc = new jsPDF();
-    doc.setFont('malgun');
-
-    // 이미지가 있을 때 Base64로 변환
-    if (profileImg) {
-      const imageBase64: string = (await convertImgToBase64(profileImg)) as string;
-      // 이미지 추가: 좌표(x, y), 크기(width, height) 설정
-      doc.addImage(imageBase64, 'PNG', 150, 20, 30, 40); // x=150, y=10, width=40, height=40
-    }
-
-    // 이름, 직무, 연락처 등 기본 정보 추가
-    doc.setFontSize(20);
-    doc.text(`${name}`, 20, 30); // 이름
-
-    doc.setFontSize(12);
-    doc.text(`Front End`, 20, 40); // 직무
-    doc.text(`연락처: ${phoneNum} | 이메일: ${email}`, 20, 50); // 연락처
-
-    // 경력 섹션
-    let yPosition = 65;
-    doc.setFontSize(16);
-    !!expArray.length && doc.text('경력', 20, yPosition); // 섹션 제목
-
-    yPosition += 10;
-    doc.setFontSize(12);
-    expArray.forEach((exp, idx) => {
-      doc.text(`${exp.exp_region} | ${exp.exp_position}`, 20, yPosition); // 회사명 및 직위
-      doc.text(`${exp.exp_period}`, 150, yPosition); // 기간
-
-      yPosition += 10;
-      doc.text(`${exp.exp_desc}`, 20, yPosition); // 상세 설명
-
-      yPosition += 15;
-    });
-
-    // 학력 섹션
-    yPosition += 10;
-    doc.setFontSize(16);
-    !!eduArray.length && doc.text('학력', 20, yPosition); // 섹션 제목
-
-    yPosition += 10;
-    eduArray.forEach((edu, idx) => {
-      doc.text(`${edu.school_name} | ${edu.major}`, 20, yPosition); // 학교명 및 전공
-      doc.text(`${edu.graduated_at}`, 150, yPosition); // 졸업일자
-
-      yPosition += 15;
-    });
-
-    // 자격증 섹션
-    yPosition += 10;
-    doc.setFontSize(16);
-    !!licArray.length && doc.text('자격증 / 면허증', 20, yPosition); // 섹션 제목
-
-    yPosition += 10;
-    licArray.forEach((lic, idx) => {
-      doc.text(`${lic.lic_title} | ${lic.lic_agency}`, 20, yPosition); // 자격증명 및 발급기관
-      doc.text(`${lic.lic_date}`, 150, yPosition); // 자격증 취득일
-
-      yPosition += 15;
-    });
-
-    return doc;
-  };
-  const openNewTabForPdf = async () => {
-    const doc = await makeResumePdf();
-    const pdfBlob = doc.output('blob');
-    const pdfUrl = URL.createObjectURL(pdfBlob);
-    window.open(pdfUrl, '_blank');
-  };
   const testLogin = async () => {
     const { data, error } = await browserClient.auth.signInWithPassword({
       email: 'yt@yt.com',
@@ -254,549 +168,54 @@ const ResumeAddPage = ({ searchParams: { query_post_id } }: Props) => {
       console.log('로그아웃 됨');
     }
   };
-  //NOTE - 포인트 초과 검사 로직
-  const isUsablePoint = async (use_point: number | string) => {
-    // const { data: userSession, error: userSessionError } = await browserClient.auth.getSession();
-    // if (userSessionError) {
-    //   console.log('userSessionError :>> ', userSessionError);
-    // } else {
-    //   // console.log('userSession :>> ', userSession);
-    // }
-    const { data: userPointData, error: userPointError } = await browserClient
-      .from('point')
-      .select('user_point')
-      .eq('user_id', userId);
-    if (userPointError) throw new Error(userPointError.message);
-    const remainPoint = userPointData[0].user_point;
-    console.log('remainPoint :>> ', remainPoint);
-    console.log(+use_point > remainPoint);
-    if (use_point > remainPoint) return false;
-    return true;
-  };
-  const isValidToUpload = async () => {
-    const titleValid = !!title;
-    if (!titleValid) {
-      alert('이력서 제목을 작성해주세요!');
-      titleRef.current?.focus();
-      return false;
-    }
-    const pointValid = !!(point + '');
-    if (!pointValid) {
-      alert('채택 포인트를 입력해주세요!');
-      pointRef.current?.focus();
-      return false;
-    }
-    //NOTE - 포인트 초과 검사
-    const isPointUsable = await isUsablePoint(point);
-    if (!isPointUsable) {
-      console.log('1 :>> ', 1);
-      alert('보유중인 포인트를 초과하는 양은 사용할 수 없습니다!');
-      pointRef.current?.focus();
-      return false;
-    }
-    const nameValid = !!name;
-    if (!nameValid) {
-      alert('이름을 작성해주세요!');
-      nameRef.current?.focus();
-      return false;
-    }
-    const genderValid = !!gender;
-    if (!genderValid) {
-      alert('성별을 작성해주세요!');
-      genderRef.current?.focus();
-      return false;
-    }
-    const phoneNumValid = !!phoneNum;
-    if (!phoneNumValid) {
-      alert('번호를 작성해주세요!');
-      phoneNumRef.current?.focus();
-      return false;
-    }
-    const emailValid = !!email;
-    if (!emailValid) {
-      alert('이메일을 작성해주세요!');
-      emailRef.current?.focus();
-      return false;
-    }
-    const addressValid = !!address;
-    if (!addressValid) {
-      alert('주소를 작성해주세요!');
-      addressRef.current?.focus();
-      return false;
-    }
-    const regionValid = !!region;
-    if (!regionValid) {
-      alert('근무 희망 지역을 작성해주세요!');
-      regionRef.current?.focus();
-      return false;
-    }
-    const expYearsValid = !!(expYears + '');
-    if (!expYearsValid) {
-      alert('경력을 작성해주세요! 신입인 경우 0을 입력해주세요!');
-      expYearsRef.current?.focus();
-      return false;
-    }
-    const resumeDescValid = !!resumeDesc;
-    if (!resumeDescValid) {
-      alert('이력서 관련 내용을 작성해주세요!');
-      resumeDescRef.current?.focus();
-      return false;
-    }
-    return true;
-  };
-  const uploadPdfToStorage = async () => {
-    const isValidToUploadData = await isValidToUpload();
-    if (!isValidToUploadData) return;
-    const doc = await makeResumePdf();
-    const pdfDoc = doc.output('blob');
-    const pdfFile = new File([pdfDoc], `${title}`, { type: 'application/pdf' });
-    // const postId = crypto.randomUUID();
-    console.log(doc);
-    const { data, error } = await browserClient.storage.from('user_resume').upload(`${postId}_resume`, pdfFile);
-    if (error) {
-      console.log('error :>> ', error);
-      throw new Error(error.message);
-    }
-    const {
-      data: { publicUrl }
-    } = browserClient.storage.from('user_resume').getPublicUrl(`${postId}_resume`);
-
-    console.log('data :>> ', data);
-    // const { data: userSession, error: userSessionError } = await browserClient.auth.getSession();
-    // if (userSessionError) {
-    //   console.log('userSessionError :>> ', userSessionError);
-    // } else {
-    //   console.log('userSession :>> ', userSession);
-    // }
-    const resumeFormData = {
-      user_uuid: userId,
-      post_id: postId,
-      use_point: point,
-      isadopted: false,
-      experience: expYears,
-      region: region,
-      post_title: title,
-      resume_url: publicUrl,
-      portfolio_url: '',
-      post_desc: resumeDesc,
-      name,
-      gender,
-      phoneNum,
-      email,
-      address
-    };
-
-    const { data: resumePostData, error: resumePostError } = await browserClient
-      .from('post_detail')
-      .insert([resumeFormData]);
-    if (resumePostError) {
-      console.log('resumePostError :>> ', resumePostError);
-      throw new Error(resumePostError.message);
-    }
-    console.log('resumePostData :>> ', resumePostData);
-
-    // const a =
-    !!eduArray.length &&
-      eduArray.forEach(async (edu) => {
-        const eduFormData = {
-          post_id: postId,
-          user_uuid: userId,
-          ...edu
-        };
-        const { data: eduPostDtat, error: eduPostError } = await browserClient
-          .from('post_detail_education')
-          .insert([eduFormData]);
-      });
-
-    // const b =
-    !!expArray.length &&
-      expArray.forEach(async (exp) => {
-        const expFormData = {
-          post_id: postId,
-          user_uuid: userId,
-          ...exp
-        };
-        const { data: expPostDtat, error: expPostError } = await browserClient
-          .from('post_detail_experience')
-          .insert([expFormData]);
-      });
-
-    // const c =
-    !!licArray.length &&
-      licArray.forEach(async (lic) => {
-        const licFormData = {
-          post_id: postId,
-          user_uuid: userId,
-          ...lic
-        };
-        const { data: licPostDtat, error: licPostError } = await browserClient
-          .from('post_detail_license')
-          .insert([licFormData]);
-      });
-    // const d = new Promise((reject) => {
-    //   setTimeout(() => reject('실패!'), 5000);
-    // });
-    // Promise.all([a, b, c, d])
-    //   .then((res) => console.log('res :>> ', res))
-    //   .catch((err) => console.log('err :>> ', err));
-  };
-  const updatePdfToStorage = async () => {
-    const isValidToUploadData = await isValidToUpload();
-    if (!isValidToUploadData) return;
-    const doc = await makeResumePdf();
-    const pdfDoc = doc.output('blob');
-    const pdfFile = new File([pdfDoc], `${title}`, { type: 'application/pdf' });
-
-    const { data, error } = await browserClient.storage.from('user_resume').update(`${query_post_id}_resume`, pdfFile, {
-      cacheControl: '3600',
-      upsert: true
-    });
-    if (error) {
-      console.log('error :>> ', error);
-      throw new Error(error.message);
-    }
-    const {
-      data: { publicUrl }
-    } = browserClient.storage.from('user_resume').getPublicUrl(`${query_post_id}_resume`);
-
-    const resumeFormData = {
-      user_uuid: userId,
-      post_id: query_post_id,
-      use_point: point,
-      isadopted,
-      experience: expYears,
-      region,
-      post_title: title,
-      resume_url: publicUrl,
-      portfolio_url: '',
-      post_desc: resumeDesc,
-      name,
-      gender,
-      phoneNum,
-      email,
-      address
-    };
-
-    const { data: resumePostData, error: resumePostError } = await browserClient
-      .from('post_detail')
-      .update([resumeFormData])
-      .eq('post_id', query_post_id);
-    if (resumePostError) {
-      console.log('resumePostError :>> ', resumePostError);
-      throw new Error(resumePostError.message);
-    }
-
-    !!eduArray.length &&
-      eduArray.forEach(async (edu) => {
-        const eduFormData = {
-          post_id: query_post_id,
-          user_uuid: userId,
-          ...edu
-        };
-        const { data: eduPostDtat, error: eduPostError } = await browserClient
-          .from('post_detail_education')
-          .update([eduFormData])
-          .eq('edu_id', edu.edu_id);
-      });
-
-    !!expArray.length &&
-      expArray.forEach(async (exp) => {
-        const expFormData = {
-          post_id: query_post_id,
-          user_uuid: userId,
-          ...exp
-        };
-        const { data: expPostDtat, error: expPostError } = await browserClient
-          .from('post_detail_experience')
-          .update([expFormData])
-          .eq('exp_id', exp.exp_id);
-      });
-
-    !!licArray.length &&
-      licArray.forEach(async (lic) => {
-        const licFormData = {
-          post_id: query_post_id,
-          user_uuid: userId,
-          ...lic
-        };
-        const { data: licPostDtat, error: licPostError } = await browserClient
-          .from('post_detail_license')
-          .update([licFormData])
-          .eq('lic_id', lic.lic_id);
-      });
-  };
-  const savePdfToLocal = async () => {
-    const doc = await makeResumePdf();
-    doc.save(`${title ? title : '이력서'}`);
-  };
   return (
     <div className="flex flex-row pl-[257px]">
       <SideBarByPage>
-        <div className="flex flex-col gap-[10px]">
-          {/* <button
-            onClick={async () => {
-              await browserClient.auth.signInWithPassword({
-                email: 'yt@yt.com',
-                password: 'ytytyt'
-              });
-            }}
-          >
-            임시로그인
-          </button> */}
-          <Button onClick={() => openNewTabForPdf()}>미리보기</Button>
-          <Button onClick={() => (query_post_id ? updatePdfToStorage() : uploadPdfToStorage())}>이력서 등록</Button>
-          <Button onClick={() => savePdfToLocal()}>이력서 저장</Button>
-        </div>
+        <SideBarItem
+          queryString={query_post_id && query_post_id}
+          openNewTabForPdf={openNewTabForPdf}
+          handleUploadPdf={handleUploadPdf}
+          savePdfToLocal={savePdfToLocal}
+        />
       </SideBarByPage>
-      <div className=" border border-solid border-black flex flex-col justify-center items-center gap-[20px] py-[20px] w-[calc(100vw-303px)]">
-        <section id="resumeTitleSection" className="flex flex-row justify-center gap-[10px]">
-          <Input placeholder="OOO님의 이력서" size="lg" value={title} onChange={handleTitle} ref={titleRef} />
-          <Input
-            isLabeled={true}
-            labelText="*채택 포인트 : "
-            value={point}
-            onChange={handlePoint}
-            ref={pointRef}
-            size="sm"
-          />
-        </section>
-        <section className="flex flex-row gap-[30px] justify-center items-center">
-          <div>
-            <label htmlFor="profileImg">
-              {profileImg ? (
-                <img
-                  src={`${URL.createObjectURL(profileImg)}`}
-                  className="flex justify-center items-center rounded-[20px] w-[200px] h-[267px] border-[2px] border-black border-solid"
-                />
-              ) : (
-                <div className="flex justify-center items-center rounded-[20px] px-[5px] w-[200px] h-[267px] bg-[#e6e6e6] border-[5px] border-black border-dashed">
-                  <p>프로필 이미지 첨부</p>
-                </div>
-              )}
-            </label>
-            <input
-              id="profileImg"
-              type="file"
-              className="hidden"
-              onChange={(e) => handleProfileImg(e)}
-              accept="image/png" //NOTE - pdf설정때문에 png만 가능하게 했음, 추가방식 고민해보겠음
-            />
-          </div>
-          <div className="flex flex-col justify-center items-start gap-[10px]">
-            <Input
-              isLabeled={true}
-              labelText="*경력 : "
-              name="experience"
-              size="sm"
-              value={expYears}
-              onChange={handleExpYears}
-              ref={expYearsRef}
-            />
-            <Input isLabeled={true} labelText="*이름 : " name="name" value={name} onChange={handleName} ref={nameRef} />
-            <Input
-              isLabeled={true}
-              labelText="*성별 : "
-              name="gender"
-              value={gender}
-              onChange={handleGender}
-              ref={genderRef}
-              placeholder="남성/여성"
-            />
-            <Input
-              isLabeled={true}
-              labelText="*이메일 : "
-              name="email"
-              value={email}
-              onChange={handleEmail}
-              ref={emailRef}
-              placeholder="example@ex.com"
-            />
-            <Input
-              isLabeled={true}
-              labelText="*전화번호 : "
-              name="phoneNum"
-              value={phoneNum}
-              onChange={handlePhoneNum}
-              ref={phoneNumRef}
-              placeholder="010-0000-0000"
-            />
-            <Input
-              isLabeled={true}
-              labelText="*근무희망지 : "
-              name="region"
-              value={region}
-              onChange={handleRegion}
-              ref={regionRef}
-            />
-            <Input
-              isLabeled={true}
-              labelText="*주소 : "
-              size="long"
-              name="address"
-              value={address}
-              onChange={handleAddress}
-              ref={addressRef}
-            />
-          </div>
-        </section>
-        <section>
-          <div className="flex flex-row gap-[5px] my-[10px]">
-            <p className="flex justify-start items-center w-[500px] px-[10px] border-b-2 border-black border-solid">
-              학력
-            </p>
-            <Button onClick={() => addForm('education')}>+</Button>
-          </div>
-          <ul className="flex flex-col items-center gap-[15px]">
-            {eduArray.map((edu, idx) => {
-              return (
-                <li
-                  key={edu.edu_id}
-                  className="flex flex-col gap-[10px] border border-black border-solid w-[350px] p-[20px] rounded-[20px]"
-                >
-                  <div className="flex justify-end">
-                    <button className="w-[13px]" onClick={() => deleteForm('education', edu.edu_id)}>
-                      <img src="/assets/modalCloseButton.png" alt="X" />
-                    </button>
-                  </div>
-                  <div className="flex flex-col gap-[10px]">
-                    <Input
-                      isLabeled={true}
-                      labelText="졸업년월 : "
-                      value={edu.graduated_at}
-                      onChange={(e) => handleArray(idx, 'graduated_at', setEduArray, e)}
-                      placeholder="2024.10.14"
-                    />
-                    <Input
-                      isLabeled={true}
-                      labelText="학교명 : "
-                      value={edu.school_name}
-                      onChange={(e) => handleArray(idx, 'school_name', setEduArray, e)}
-                    />
-                    <Input
-                      isLabeled={true}
-                      labelText="전공 : "
-                      value={edu.major}
-                      onChange={(e) => handleArray(idx, 'major', setEduArray, e)}
-                    />
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </section>
-        <section>
-          <div className="flex flex-row gap-[5px] my-[10px]">
-            <div className="flex justify-start items-center w-[500px] px-[10px] border-b-2 border-black border-solid">
-              경력사항
-            </div>
-            <Button onClick={() => addForm('experience')}>+</Button>
-          </div>
-          <ul className="flex flex-col items-center gap-[15px]">
-            {expArray.map((exp, idx) => {
-              return (
-                <li
-                  key={exp.exp_id}
-                  className="flex flex-col gap-[10px] border border-black border-solid w-[350px] p-[20px] rounded-[20px]"
-                >
-                  <div className="flex justify-end">
-                    <button className="w-[13px]" onClick={() => deleteForm('experience', exp.exp_id)}>
-                      <img src="/assets/modalCloseButton.png" alt="X" />
-                    </button>
-                  </div>
-                  <div className="flex flex-col gap-[10px]">
-                    <Input
-                      isLabeled={true}
-                      labelText="기간 : "
-                      value={exp.exp_period}
-                      onChange={(e) => handleArray(idx, 'exp_period', setExpArray, e)}
-                      placeholder="2020.10.14~2024.10.14"
-                    />
-                    <Input
-                      isLabeled={true}
-                      labelText="근무처 : "
-                      value={exp.exp_region}
-                      onChange={(e) => handleArray(idx, 'exp_region', setExpArray, e)}
-                    />
-                    <Input
-                      isLabeled={true}
-                      labelText="직위 : "
-                      value={exp.exp_position}
-                      onChange={(e) => handleArray(idx, 'exp_position', setExpArray, e)}
-                      placeholder="ex) PM"
-                    />
-                    <Input
-                      isLabeled={true}
-                      labelText="업무내용 : "
-                      value={exp.exp_desc}
-                      onChange={(e) => handleArray(idx, 'exp_desc', setExpArray, e)}
-                      placeholder="내일배움캠프 클라이언트 DB관리"
-                    />
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </section>
-        <section>
-          <div className="flex flex-row gap-[5px] my-[10px]">
-            <div className="flex justify-start items-center w-[500px] px-[10px] border-b-2 border-black border-solid">
-              보유기술 / 자격증
-            </div>
-            <Button onClick={() => addForm('license')}>+</Button>
-          </div>
-          <ul className="flex flex-col items-center gap-[15px]">
-            {licArray.map((lic, idx) => {
-              return (
-                <li
-                  key={lic.lic_id}
-                  className="flex flex-col gap-[10px] border border-black border-solid w-[350px] p-[20px] rounded-[20px]"
-                >
-                  <div className="flex justify-end">
-                    <button className="w-[13px]" onClick={() => deleteForm('license', lic.lic_id)}>
-                      <img src="/assets/modalCloseButton.png" alt="X" />
-                    </button>
-                  </div>
-                  <div className="flex flex-col gap-[10px]">
-                    <Input
-                      isLabeled={true}
-                      labelText="취득 년월일 : "
-                      value={lic.lic_date}
-                      onChange={(e) => handleArray(idx, 'lic_date', setLicArray, e)}
-                      placeholder="2024.10.14"
-                    />
-                    <Input
-                      isLabeled={true}
-                      labelText="자격/면허증 : "
-                      value={lic.lic_title}
-                      onChange={(e) => handleArray(idx, 'lic_title', setLicArray, e)}
-                      placeholder="정보처리기사"
-                    />
-                    <Input
-                      isLabeled={true}
-                      labelText="시행처 : "
-                      value={lic.lic_agency}
-                      onChange={(e) => handleArray(idx, 'lic_agency', setLicArray, e)}
-                      placeholder="한국산업인력공단"
-                    />
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </section>
-        <section>
-          <div className="flex flex-col justify-start">
-            {/* <label htmlFor="resumeDescription">*내용 입력</label> */}
-            <textarea
-              id="resumeDescription"
-              className="rounded-[20px] border border-[#919191] py-[15px] px-[10px] border-solid w-[800px] min-h-[150px] focus:outline-none"
-              placeholder="이력서 피드백 혹은 추가자료 관련 작성하고 싶은 내용을 적어주세요."
-              value={resumeDesc}
-              onChange={handleResumeDesc}
-              ref={resumeDescRef}
-            />
-          </div>
-        </section>
+      <div className="flex flex-col justify-center items-center gap-[20px] py-[20px] w-[calc(100vw-303px)]">
+        <ResumeTopSection
+          title={title}
+          handleTitle={handleTitle}
+          titleRef={titleRef}
+          point={point}
+          handlePoint={handlePoint}
+          pointRef={pointRef}
+        />
+        <PersonalDataSection
+          profileImg={profileImg && profileImg}
+          handleProfileImg={handleProfileImg}
+          expYears={expYears}
+          handleExpYears={handleExpYears}
+          expYearsRef={expYearsRef}
+          name={name}
+          handleName={handleName}
+          nameRef={nameRef}
+          gender={gender}
+          handleGender={handleGender}
+          genderRef={genderRef}
+          email={email}
+          handleEmail={handleEmail}
+          emailRef={emailRef}
+          phoneNum={phoneNum}
+          handlePhoneNum={handlePhoneNum}
+          phoneNumRef={phoneNumRef}
+          region={region}
+          handleRegion={handleRegion}
+          regionRef={regionRef}
+          address={address}
+          handleAddress={handleAddress}
+          addressRef={addressRef}
+        />
+        <EducationSection addForm={addForm} eduArray={eduArray} deleteForm={deleteForm} setEduArray={setEduArray} />
+        <ExperienceSection addForm={addForm} expArray={expArray} deleteForm={deleteForm} setExpArray={setExpArray} />
+        <LicenseSection addForm={addForm} licArray={licArray} deleteForm={deleteForm} setLicArray={setLicArray} />
+        <ResumeDescSection resumeDesc={resumeDesc} handleResumeDesc={handleResumeDesc} resumeDescRef={resumeDescRef} />
       </div>
     </div>
   );

--- a/src/app/_components/resumeadd/EducationBox.tsx
+++ b/src/app/_components/resumeadd/EducationBox.tsx
@@ -1,0 +1,45 @@
+import { EducationType } from '@/type/resumeTypes';
+import Input from '../common/Input';
+import { handleArrayByData } from '@/utils/resume/handleArrayByData';
+
+type Props = {
+  edu: EducationType;
+  idx: number;
+  deleteForm: (objName: string, id: string) => void;
+  setEduArray: React.Dispatch<React.SetStateAction<EducationType[]>>;
+};
+
+const EducationBox = ({ edu, idx, deleteForm, setEduArray }: Props) => {
+  return (
+    <li className="flex flex-col gap-[10px] border border-black border-solid w-[350px] p-[20px] rounded-[20px]">
+      <div className="flex justify-end">
+        <button className="w-[13px]" onClick={() => deleteForm('education', edu.edu_id)}>
+          <img src="/assets/modalCloseButton.png" alt="X" />
+        </button>
+      </div>
+      <div className="flex flex-col gap-[10px]">
+        <Input
+          isLabeled={true}
+          labelText="졸업년월 : "
+          value={edu.graduated_at}
+          onChange={(e) => handleArrayByData(idx, 'graduated_at', setEduArray, e)}
+          placeholder="2024.10.14"
+        />
+        <Input
+          isLabeled={true}
+          labelText="학교명 : "
+          value={edu.school_name}
+          onChange={(e) => handleArrayByData(idx, 'school_name', setEduArray, e)}
+        />
+        <Input
+          isLabeled={true}
+          labelText="전공 : "
+          value={edu.major}
+          onChange={(e) => handleArrayByData(idx, 'major', setEduArray, e)}
+        />
+      </div>
+    </li>
+  );
+};
+
+export default EducationBox;

--- a/src/app/_components/resumeadd/EducationSection.tsx
+++ b/src/app/_components/resumeadd/EducationSection.tsx
@@ -1,0 +1,30 @@
+import { EducationType } from '@/type/resumeTypes';
+import Button from '../common/Button';
+import EducationBox from './EducationBox';
+
+type Props = {
+  addForm: (objName: string) => void;
+  eduArray: EducationType[];
+  deleteForm: (objName: string, id: string) => void;
+  setEduArray: React.Dispatch<React.SetStateAction<EducationType[]>>;
+};
+
+const EducationSection = ({ addForm, eduArray, deleteForm, setEduArray }: Props) => {
+  return (
+    <section>
+      <div className="flex flex-row gap-[5px] my-[10px]">
+        <p className="flex justify-start items-center w-[500px] px-[10px] border-b-2 border-black border-solid">학력</p>
+        <Button onClick={() => addForm('education')}>+</Button>
+      </div>
+      <ul className="flex flex-col items-center gap-[15px]">
+        {eduArray.map((edu, idx) => {
+          return (
+            <EducationBox key={edu.edu_id} edu={edu} idx={idx} deleteForm={deleteForm} setEduArray={setEduArray} />
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+export default EducationSection;

--- a/src/app/_components/resumeadd/ExperienceBox.tsx
+++ b/src/app/_components/resumeadd/ExperienceBox.tsx
@@ -1,0 +1,53 @@
+import { handleArrayByData } from '@/utils/resume/handleArrayByData';
+import Input from '../common/Input';
+import { ExperienceType } from '@/type/resumeTypes';
+
+type Props = {
+  exp: ExperienceType;
+  idx: number;
+  deleteForm: (objName: string, id: string) => void;
+  setExpArray: React.Dispatch<React.SetStateAction<ExperienceType[]>>;
+};
+
+const ExperienceBox = ({ exp, idx, deleteForm, setExpArray }: Props) => {
+  return (
+    <li className="flex flex-col gap-[10px] border border-black border-solid w-[350px] p-[20px] rounded-[20px]">
+      <div className="flex justify-end">
+        <button className="w-[13px]" onClick={() => deleteForm('experience', exp.exp_id)}>
+          <img src="/assets/modalCloseButton.png" alt="X" />
+        </button>
+      </div>
+      <div className="flex flex-col gap-[10px]">
+        <Input
+          isLabeled={true}
+          labelText="기간 : "
+          value={exp.exp_period}
+          onChange={(e) => handleArrayByData(idx, 'exp_period', setExpArray, e)}
+          placeholder="2020.10.14~2024.10.14"
+        />
+        <Input
+          isLabeled={true}
+          labelText="근무처 : "
+          value={exp.exp_region}
+          onChange={(e) => handleArrayByData(idx, 'exp_region', setExpArray, e)}
+        />
+        <Input
+          isLabeled={true}
+          labelText="직위 : "
+          value={exp.exp_position}
+          onChange={(e) => handleArrayByData(idx, 'exp_position', setExpArray, e)}
+          placeholder="ex) PM"
+        />
+        <Input
+          isLabeled={true}
+          labelText="업무내용 : "
+          value={exp.exp_desc}
+          onChange={(e) => handleArrayByData(idx, 'exp_desc', setExpArray, e)}
+          placeholder="내일배움캠프 클라이언트 DB관리"
+        />
+      </div>
+    </li>
+  );
+};
+
+export default ExperienceBox;

--- a/src/app/_components/resumeadd/ExperienceSection.tsx
+++ b/src/app/_components/resumeadd/ExperienceSection.tsx
@@ -1,0 +1,32 @@
+import { ExperienceType } from '@/type/resumeTypes';
+import Button from '../common/Button';
+import ExperienceBox from './ExperienceBox';
+
+type Props = {
+  addForm: (objName: string) => void;
+  expArray: ExperienceType[];
+  deleteForm: (objName: string, id: string) => void;
+  setExpArray: React.Dispatch<React.SetStateAction<ExperienceType[]>>;
+};
+
+const ExperienceSection = ({ addForm, expArray, deleteForm, setExpArray }: Props) => {
+  return (
+    <section>
+      <div className="flex flex-row gap-[5px] my-[10px]">
+        <div className="flex justify-start items-center w-[500px] px-[10px] border-b-2 border-black border-solid">
+          경력사항
+        </div>
+        <Button onClick={() => addForm('experience')}>+</Button>
+      </div>
+      <ul className="flex flex-col items-center gap-[15px]">
+        {expArray.map((exp, idx) => {
+          return (
+            <ExperienceBox key={exp.exp_id} exp={exp} idx={idx} deleteForm={deleteForm} setExpArray={setExpArray} />
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+export default ExperienceSection;

--- a/src/app/_components/resumeadd/LicenseBox.tsx
+++ b/src/app/_components/resumeadd/LicenseBox.tsx
@@ -1,0 +1,47 @@
+import { LicenseType } from '@/type/resumeTypes';
+import Input from '../common/Input';
+import { handleArrayByData } from '@/utils/resume/handleArrayByData';
+
+type Props = {
+  lic: LicenseType;
+  idx: number;
+  deleteForm: (objName: string, id: string) => void;
+  setLicArray: React.Dispatch<React.SetStateAction<LicenseType[]>>;
+};
+
+function LicenseBox({ lic, idx, deleteForm, setLicArray }: Props) {
+  return (
+    <li className="flex flex-col gap-[10px] border border-black border-solid w-[350px] p-[20px] rounded-[20px]">
+      <div className="flex justify-end">
+        <button className="w-[13px]" onClick={() => deleteForm('license', lic.lic_id)}>
+          <img src="/assets/modalCloseButton.png" alt="X" />
+        </button>
+      </div>
+      <div className="flex flex-col gap-[10px]">
+        <Input
+          isLabeled={true}
+          labelText="취득 년월일 : "
+          value={lic.lic_date}
+          onChange={(e) => handleArrayByData(idx, 'lic_date', setLicArray, e)}
+          placeholder="2024.10.14"
+        />
+        <Input
+          isLabeled={true}
+          labelText="자격/면허증 : "
+          value={lic.lic_title}
+          onChange={(e) => handleArrayByData(idx, 'lic_title', setLicArray, e)}
+          placeholder="정보처리기사"
+        />
+        <Input
+          isLabeled={true}
+          labelText="시행처 : "
+          value={lic.lic_agency}
+          onChange={(e) => handleArrayByData(idx, 'lic_agency', setLicArray, e)}
+          placeholder="한국산업인력공단"
+        />
+      </div>
+    </li>
+  );
+}
+
+export default LicenseBox;

--- a/src/app/_components/resumeadd/LicenseSection.tsx
+++ b/src/app/_components/resumeadd/LicenseSection.tsx
@@ -1,0 +1,30 @@
+import { LicenseType } from '@/type/resumeTypes';
+import Button from '../common/Button';
+import LicenseBox from './LicenseBox';
+
+type Props = {
+  addForm: (objName: string) => void;
+  licArray: LicenseType[];
+  deleteForm: (objName: string, id: string) => void;
+  setLicArray: React.Dispatch<React.SetStateAction<LicenseType[]>>;
+};
+
+const LicenseSection = ({ addForm, licArray, deleteForm, setLicArray }: Props) => {
+  return (
+    <section>
+      <div className="flex flex-row gap-[5px] my-[10px]">
+        <div className="flex justify-start items-center w-[500px] px-[10px] border-b-2 border-black border-solid">
+          보유기술 / 자격증
+        </div>
+        <Button onClick={() => addForm('license')}>+</Button>
+      </div>
+      <ul className="flex flex-col items-center gap-[15px]">
+        {licArray.map((lic, idx) => {
+          return <LicenseBox key={lic.lic_id} lic={lic} idx={idx} deleteForm={deleteForm} setLicArray={setLicArray} />;
+        })}
+      </ul>
+    </section>
+  );
+};
+
+export default LicenseSection;

--- a/src/app/_components/resumeadd/PersonalDataSection.tsx
+++ b/src/app/_components/resumeadd/PersonalDataSection.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import ProfileImgLabel from './ProfileImgLabel';
+import Input from '../common/Input';
+import { HandleInputType } from '@/hooks/useInput';
+
+type Props = {
+  profileImg?: File;
+  handleProfileImg: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  expYears: string | number;
+  handleExpYears: HandleInputType;
+  expYearsRef: React.MutableRefObject<HTMLInputElement | null>;
+  name: string | number;
+  handleName: HandleInputType;
+  nameRef: React.MutableRefObject<HTMLInputElement | null>;
+  gender: string | number;
+  handleGender: HandleInputType;
+  genderRef: React.MutableRefObject<HTMLInputElement | null>;
+  email: string | number;
+  handleEmail: HandleInputType;
+  emailRef: React.MutableRefObject<HTMLInputElement | null>;
+  phoneNum: string | number;
+  handlePhoneNum: HandleInputType;
+  phoneNumRef: React.MutableRefObject<HTMLInputElement | null>;
+  region: string | number;
+  handleRegion: HandleInputType;
+  regionRef: React.MutableRefObject<HTMLInputElement | null>;
+  address: string | number;
+  handleAddress: HandleInputType;
+  addressRef: React.MutableRefObject<HTMLInputElement | null>;
+};
+
+const PersonalDataSection = ({
+  profileImg,
+  handleProfileImg,
+  expYears,
+  handleExpYears,
+  expYearsRef,
+  name,
+  handleName,
+  nameRef,
+  gender,
+  handleGender,
+  genderRef,
+  email,
+  handleEmail,
+  emailRef,
+  phoneNum,
+  handlePhoneNum,
+  phoneNumRef,
+  region,
+  handleRegion,
+  regionRef,
+  address,
+  handleAddress,
+  addressRef
+}: Props) => {
+  return (
+    <section className="flex flex-row gap-[30px] justify-center items-center">
+      <div>
+        <ProfileImgLabel profileImg={profileImg} />
+        <input
+          id="profileImg"
+          type="file"
+          className="hidden"
+          onChange={(e) => handleProfileImg(e)}
+          accept="image/png" //NOTE - pdf설정때문에 png만 가능하게 했음, 추가방식 고민해보겠음
+        />
+      </div>
+      <div className="flex flex-col justify-center items-start gap-[10px]">
+        <Input
+          isLabeled={true}
+          labelText="*경력 : "
+          name="experience"
+          size="sm"
+          value={expYears}
+          onChange={handleExpYears}
+          ref={expYearsRef}
+        />
+        <Input isLabeled={true} labelText="*이름 : " name="name" value={name} onChange={handleName} ref={nameRef} />
+        <Input
+          isLabeled={true}
+          labelText="*성별 : "
+          name="gender"
+          value={gender}
+          onChange={handleGender}
+          ref={genderRef}
+          placeholder="남성/여성"
+        />
+        <Input
+          isLabeled={true}
+          labelText="*이메일 : "
+          name="email"
+          value={email}
+          onChange={handleEmail}
+          ref={emailRef}
+          placeholder="example@ex.com"
+        />
+        <Input
+          isLabeled={true}
+          labelText="*전화번호 : "
+          name="phoneNum"
+          value={phoneNum}
+          onChange={handlePhoneNum}
+          ref={phoneNumRef}
+          placeholder="010-0000-0000"
+        />
+        <Input
+          isLabeled={true}
+          labelText="*근무희망지 : "
+          name="region"
+          value={region}
+          onChange={handleRegion}
+          ref={regionRef}
+        />
+        <Input
+          isLabeled={true}
+          labelText="*주소 : "
+          size="long"
+          name="address"
+          value={address}
+          onChange={handleAddress}
+          ref={addressRef}
+        />
+      </div>
+    </section>
+  );
+};
+
+export default PersonalDataSection;

--- a/src/app/_components/resumeadd/ProfileImgLabel.tsx
+++ b/src/app/_components/resumeadd/ProfileImgLabel.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+type Props = {
+  profileImg?: File;
+};
+
+const ProfileImgLabel = ({ profileImg }: Props) => {
+  return (
+    <label htmlFor="profileImg">
+      {profileImg ? (
+        <img
+          src={`${URL.createObjectURL(profileImg)}`}
+          className="flex justify-center items-center rounded-[20px] w-[200px] h-[267px] border-[2px] border-black border-solid"
+        />
+      ) : (
+        <div className="flex justify-center items-center rounded-[20px] px-[5px] w-[200px] h-[267px] bg-[#e6e6e6] border-[5px] border-black border-dashed">
+          <p>프로필 이미지 첨부</p>
+        </div>
+      )}
+    </label>
+  );
+};
+
+export default ProfileImgLabel;

--- a/src/app/_components/resumeadd/ResumeDescSection.tsx
+++ b/src/app/_components/resumeadd/ResumeDescSection.tsx
@@ -1,0 +1,26 @@
+import { HandleInputType } from '@/hooks/useInput';
+
+type Props = {
+  resumeDesc: string | number;
+  handleResumeDesc: HandleInputType;
+  resumeDescRef: React.RefObject<HTMLTextAreaElement>;
+};
+
+const ResumeDescSection = ({ resumeDesc, handleResumeDesc, resumeDescRef }: Props) => {
+  return (
+    <section>
+      <div className="flex flex-col justify-start">
+        <textarea
+          id="resumeDescription"
+          className="rounded-[20px] border border-[#919191] py-[15px] px-[10px] border-solid w-[800px] min-h-[150px] focus:outline-none"
+          placeholder="이력서 피드백 혹은 추가자료 관련 작성하고 싶은 내용을 적어주세요."
+          value={resumeDesc}
+          onChange={handleResumeDesc}
+          ref={resumeDescRef}
+        />
+      </div>
+    </section>
+  );
+};
+
+export default ResumeDescSection;

--- a/src/app/_components/resumeadd/ResumeTopSection.tsx
+++ b/src/app/_components/resumeadd/ResumeTopSection.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Input from '../common/Input';
+import { HandleInputType } from '@/hooks/useInput';
+
+type Props = {
+  title: string | number;
+  handleTitle: HandleInputType;
+  titleRef: React.MutableRefObject<HTMLInputElement | null>;
+  point: string | number;
+  handlePoint: HandleInputType;
+  pointRef: React.MutableRefObject<HTMLInputElement | null>;
+};
+
+const ResumeTopSection = ({ title, handleTitle, titleRef, point, handlePoint, pointRef }: Props) => {
+  return (
+    <section id="resumeTitleSection" className="flex flex-row justify-center gap-[10px]">
+      <Input placeholder="OOO님의 이력서" size="lg" value={title} onChange={handleTitle} ref={titleRef} />
+      <Input
+        isLabeled={true}
+        labelText="*채택 포인트 : "
+        value={point}
+        onChange={handlePoint}
+        ref={pointRef}
+        size="sm"
+      />
+    </section>
+  );
+};
+
+export default ResumeTopSection;

--- a/src/app/_components/resumeadd/SideBarItem.tsx
+++ b/src/app/_components/resumeadd/SideBarItem.tsx
@@ -1,0 +1,22 @@
+import useResumeAddpage from '@/hooks/useResumeAddpage';
+import Button from '../common/Button';
+
+type Props = {
+  queryString?: string;
+  openNewTabForPdf: () => Promise<void>;
+  handleUploadPdf: (isUpdate: boolean) => Promise<void>;
+  savePdfToLocal: () => Promise<void>;
+};
+
+const SideBarItem = ({ queryString, openNewTabForPdf, handleUploadPdf, savePdfToLocal }: Props) => {
+  return (
+    <div className="flex flex-col gap-[10px]">
+      {/* <button onClick={testLogin}>임시로그인</button> */}
+      <Button onClick={() => openNewTabForPdf()}>미리보기</Button>
+      <Button onClick={() => handleUploadPdf(queryString ? true : false)}>이력서 등록</Button>
+      <Button onClick={() => savePdfToLocal()}>이력서 저장</Button>
+    </div>
+  );
+};
+
+export default SideBarItem;

--- a/src/constants/resumeConstants.ts
+++ b/src/constants/resumeConstants.ts
@@ -1,4 +1,4 @@
-import { EducationType, ExperienceType, LicenseType } from '@/types/ResumeType';
+import { EducationType, ExperienceType, LicenseType } from '@/type/resumeTypes';
 
 const EMPTY_EDU_OBJ: Omit<EducationType, 'edu_id'> = {
   graduated_at: '',

--- a/src/hooks/useResumeAddpage.tsx
+++ b/src/hooks/useResumeAddpage.tsx
@@ -1,0 +1,260 @@
+import { useRef, useState } from 'react';
+import useInput from './useInput';
+import { EducationType, EduFormType, ExperienceType, ExpFormType, LicenseType, LicFormType } from '@/type/resumeTypes';
+import { EMPTY_EDU_OBJ, EMPTY_EXP_OBJ, EMPTY_LIC_OBJ } from '@/constants/resumeConstants';
+import { makeResumePdf } from '@/utils/resume/makeResumePdf';
+import {
+  getUserPoint,
+  updateResumeData,
+  updateTransformedData,
+  uploadResumeData,
+  uploadTransformedData
+} from '@/utils/resume/server-action';
+import { updatePdfToStorage, uploadPdfToStorage } from '@/utils/resume/client-actions';
+import browserClient from '@/utils/supabase/client';
+import { transformResumeData } from '@/services/resumeadd/resumeaddServices';
+
+const useResumeAddpage = () => {
+  const [title, handleTitle, titleRef, setTitle] = useInput('');
+  const [name, handleName, nameRef, setName] = useInput('');
+  const [gender, handleGender, genderRef, setGender] = useInput('');
+  const [phoneNum, handlePhoneNum, phoneNumRef, setPhoneNum] = useInput('');
+  const [email, handleEmail, emailRef, setEmail] = useInput('');
+  const [address, handleAddress, addressRef, setAddress] = useInput('');
+  const [region, handleRegion, regionRef, setRegion] = useInput('');
+  const [expYears, handleExpYears, expYearsRef, setExpYears] = useInput(0);
+  const [resumeDesc, handleResumeDesc, _, setResumeDesc] = useInput('');
+  const resumeDescRef = useRef<HTMLTextAreaElement>(null);
+  const [point, handlePoint, pointRef, setPoint] = useInput(0);
+  const [profileImg, setProfileImg] = useState<File>();
+  const [postId, setPostId] = useState(crypto.randomUUID());
+  const handleProfileImg = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const targetFile = e.target.files && e.target.files[0];
+    if (targetFile) {
+      if (targetFile.type !== 'image/png') {
+        alert('png 이미지만 첨부 가능합니다.');
+        return;
+      } else {
+        setProfileImg(targetFile);
+      }
+    } else {
+      alert('파일을 업로드 해주세요!');
+      return;
+    }
+  };
+
+  const [eduArray, setEduArray] = useState<EducationType[]>([]);
+  const [expArray, setExpArray] = useState<ExperienceType[]>([]);
+  const [licArray, setLicArray] = useState<LicenseType[]>([]);
+
+  const [userId, setUserId] = useState('');
+  const [isadopted, setIsadopted] = useState(false);
+
+  const addForm = (objName: string) => {
+    switch (objName) {
+      case 'education':
+        setEduArray((prev) => [...prev, { ...EMPTY_EDU_OBJ, edu_id: crypto.randomUUID() }]);
+        break;
+      case 'experience':
+        setExpArray((prev) => [...prev, { ...EMPTY_EXP_OBJ, exp_id: crypto.randomUUID() }]);
+        break;
+      case 'license':
+        setLicArray((prev) => [...prev, { ...EMPTY_LIC_OBJ, lic_id: crypto.randomUUID() }]);
+        break;
+    }
+  };
+  const deleteForm = (objName: string, id: string) => {
+    switch (objName) {
+      case 'education':
+        setEduArray((prev) => prev.filter((edu) => edu.edu_id !== id));
+        break;
+      case 'experience':
+        setExpArray((prev) => prev.filter((exp) => exp.exp_id !== id));
+        break;
+      case 'license':
+        setLicArray((prev) => prev.filter((lic) => lic.lic_id !== id));
+        break;
+    }
+  };
+  const openNewTabForPdf = async () => {
+    const doc = await makeResumePdf(profileImg, name, phoneNum, email, expArray, eduArray, licArray);
+    const pdfBlob = doc.output('blob');
+    const pdfUrl = URL.createObjectURL(pdfBlob);
+    window.open(pdfUrl, '_blank');
+  };
+  //NOTE - 포인트 초과 검사 로직
+  const isUsablePoint = async (use_point: number | string) => {
+    const { data: userPointData, error: userPointError } = await getUserPoint(userId);
+    if (userPointError) throw new Error(userPointError.message);
+    const remainPoint = userPointData ? userPointData[0].user_point : Infinity;
+    if (use_point > remainPoint) return false;
+    return true;
+  };
+  const isValueValid = (
+    value: string | number,
+    message: string,
+    ref: React.MutableRefObject<HTMLInputElement | null> | React.RefObject<HTMLTextAreaElement>
+  ) => {
+    if (!(value + '')) {
+      alert(message);
+      ref.current?.focus();
+      return false;
+    }
+    return true;
+  };
+  const isValidToUpload = async () => {
+    if (!isValueValid(title, '이력서 제목을 작성해주세요.', titleRef)) return false;
+    if (!isValueValid(point, '채택 포인트를 입력해주세요.', pointRef)) return false;
+    //NOTE - 포인트 초과 검사
+    const isPointUsable = await isUsablePoint(point);
+    if (!isPointUsable) {
+      console.log('1 :>> ', 1);
+      alert('보유중인 포인트를 초과하는 양은 사용할 수 없습니다!');
+      pointRef.current?.focus();
+      return false;
+    }
+    if (!isValueValid(expYears, '경력을 작성해주세요. 신입인 경우 0을 입력해주세요.', expYearsRef)) return false;
+    if (!isValueValid(name, '이름을 작성해주세요.', nameRef)) return false;
+    if (!isValueValid(gender, '성별을 작성해주세요.', genderRef)) return false;
+    if (!isValueValid(email, '이메일을 작성해주세요.', emailRef)) return false;
+    if (!isValueValid(phoneNum, '번호를 작성해주세요.', phoneNumRef)) return false;
+    if (!isValueValid(region, '근무 희망 지역을 작성해주세요.', regionRef)) return false;
+    if (!isValueValid(address, '주소를 작성해주세요.', addressRef)) return false;
+    if (!isValueValid(resumeDesc, '이력서 관련 내용을 작성해주세요.', resumeDescRef)) return false;
+  };
+  const handleUploadPdf = async (isUpdate: boolean) => {
+    const isValidToUploadData = await isValidToUpload();
+    if (!isValidToUploadData) return;
+    const doc = await makeResumePdf(profileImg, name, phoneNum, email, expArray, eduArray, licArray);
+    const pdfDoc = doc.output('blob');
+    const pdfFile = new File([pdfDoc], `${title}`, { type: 'application/pdf' });
+
+    const { data: pdfData, error: pdfError } = isUpdate
+      ? await updatePdfToStorage(postId, pdfFile)
+      : await uploadPdfToStorage(postId, pdfFile);
+
+    if (pdfError) {
+      console.log('pdfError :>> ', pdfError);
+      throw new Error(pdfError.message);
+    }
+    const {
+      data: { publicUrl }
+    } = browserClient.storage.from('user_resume').getPublicUrl(`${postId}_resume`);
+
+    const resumeFormData = {
+      user_uuid: userId,
+      post_id: postId,
+      use_point: point,
+      isadopted,
+      experience: expYears,
+      region: region,
+      post_title: title,
+      resume_url: publicUrl,
+      portfolio_url: '',
+      post_desc: resumeDesc,
+      name,
+      gender,
+      phoneNum,
+      email,
+      address
+    };
+
+    const { data: resumePostData, error: resumePostError } = isUpdate
+      ? await updateResumeData(postId, resumeFormData)
+      : await uploadResumeData(resumeFormData);
+
+    if (resumePostError) {
+      console.log('resumePostError :>> ', resumePostError);
+      throw new Error(resumePostError.message);
+    }
+
+    !!eduArray.length &&
+      eduArray.forEach(async (edu) => {
+        const eduFormData: EduFormType = transformResumeData<EducationType>(postId, userId, edu);
+        const { data: eduPostDtat, error: eduPostError } = isUpdate
+          ? await updateTransformedData<EduFormType, keyof EduFormType>(eduFormData, 'post_detail_education', 'edu_id')
+          : await uploadTransformedData(eduFormData, 'post_detail_education');
+      });
+
+    !!expArray.length &&
+      expArray.forEach(async (exp) => {
+        const expFormData: ExpFormType = transformResumeData<ExperienceType>(postId, userId, exp);
+        const { data: expPostData, error: expPostError } = isUpdate
+          ? await updateTransformedData<ExpFormType, keyof ExpFormType>(expFormData, 'post_detail_experience', 'exp_id')
+          : await uploadTransformedData(expFormData, 'post_detail_experience');
+      });
+
+    !!licArray.length &&
+      licArray.forEach(async (lic) => {
+        const licFormData = transformResumeData<LicenseType>(postId, userId, lic);
+        const { data: licPostData, error: licPostError } = isUpdate
+          ? await updateTransformedData<LicFormType, keyof LicFormType>(licFormData, 'post_detail_license', 'lic_id')
+          : await uploadTransformedData(licFormData, 'post_detail_license');
+      });
+  };
+
+  const savePdfToLocal = async () => {
+    const doc = await makeResumePdf(profileImg, name, phoneNum, email, expArray, eduArray, licArray);
+    doc.save(`${title ? title : '이력서'}`);
+  };
+  return {
+    openNewTabForPdf,
+    handleUploadPdf,
+    savePdfToLocal,
+    point,
+    handlePoint,
+    pointRef,
+    title,
+    handleTitle,
+    titleRef,
+    profileImg,
+    handleProfileImg,
+    expYears,
+    handleExpYears,
+    expYearsRef,
+    name,
+    handleName,
+    nameRef,
+    gender,
+    handleGender,
+    genderRef,
+    email,
+    handleEmail,
+    emailRef,
+    phoneNum,
+    handlePhoneNum,
+    phoneNumRef,
+    region,
+    handleRegion,
+    regionRef,
+    address,
+    handleAddress,
+    addressRef,
+    addForm,
+    eduArray,
+    deleteForm,
+    expArray,
+    licArray,
+    resumeDesc,
+    handleResumeDesc,
+    resumeDescRef,
+    setUserId,
+    setTitle,
+    setName,
+    setGender,
+    setPhoneNum,
+    setEmail,
+    setAddress,
+    setRegion,
+    setExpYears,
+    setResumeDesc,
+    setPoint,
+    setPostId,
+    setIsadopted,
+    setEduArray,
+    setExpArray,
+    setLicArray
+  };
+};
+
+export default useResumeAddpage;

--- a/src/services/resumeadd/resumeaddServices.ts
+++ b/src/services/resumeadd/resumeaddServices.ts
@@ -1,0 +1,13 @@
+const transformResumeData = <T>(
+  postId: string,
+  userId: string,
+  data: T
+): T & { post_id: string; user_uuid: string } => {
+  return {
+    post_id: postId,
+    user_uuid: userId,
+    ...data
+  };
+};
+
+export { transformResumeData };

--- a/src/type/resumeTypes.ts
+++ b/src/type/resumeTypes.ts
@@ -1,0 +1,65 @@
+export interface ResumeFormType {
+  user_uuid: string;
+  post_id: string;
+  use_point: string | number;
+  isadopted: boolean;
+  experience: string | number;
+  region: string | number;
+  post_title: string | number;
+  resume_url: string;
+  portfolio_url: string;
+  post_desc: string | number;
+  name: string | number;
+  gender: string | number;
+  phoneNum: string | number;
+  email: string | number;
+  address: string | number;
+}
+
+export interface EduFormType {
+  edu_id: string;
+  graduated_at: string;
+  school_name: string;
+  major: string;
+  post_id: string;
+  user_uuid: string;
+}
+
+export interface ExpFormType {
+  exp_id: string;
+  exp_period: string;
+  exp_region: string;
+  exp_position: string;
+  exp_desc: string;
+  post_id: string;
+  user_uuid: string;
+}
+
+export interface LicFormType {
+  lic_id: string;
+  lic_date: string;
+  lic_title: string;
+  lic_agency: string;
+  post_id: string;
+  user_uuid: string;
+}
+
+export interface EducationType {
+  edu_id: string;
+  graduated_at: string;
+  school_name: string;
+  major: string;
+}
+export interface ExperienceType {
+  exp_id: string;
+  exp_period: string;
+  exp_region: string;
+  exp_position: string;
+  exp_desc: string;
+}
+export interface LicenseType {
+  lic_id: string;
+  lic_date: string;
+  lic_title: string;
+  lic_agency: string;
+}

--- a/src/utils/resume/client-actions.ts
+++ b/src/utils/resume/client-actions.ts
@@ -1,0 +1,16 @@
+import browserClient from '../supabase/client';
+
+const uploadPdfToStorage = async (postId: string, pdfFile: File) => {
+  const { data, error } = await browserClient.storage.from('user_resume').upload(`${postId}_resume`, pdfFile);
+  return { data, error };
+};
+
+const updatePdfToStorage = async (query_post_id: string, pdfFile: File) => {
+  const { data, error } = await browserClient.storage.from('user_resume').update(`${query_post_id}_resume`, pdfFile, {
+    cacheControl: '3600',
+    upsert: true
+  });
+  return { data, error };
+};
+
+export { updatePdfToStorage, uploadPdfToStorage };

--- a/src/utils/resume/handleArrayByData.ts
+++ b/src/utils/resume/handleArrayByData.ts
@@ -1,0 +1,15 @@
+export const handleArrayByData = <T>(
+  idx: number,
+  name: string,
+  setState: React.Dispatch<React.SetStateAction<T[]>>,
+  e: React.ChangeEvent<HTMLInputElement>
+) => {
+  setState((prev) => {
+    const changedArray = [...prev];
+    changedArray[idx] = {
+      ...changedArray[idx],
+      [name]: e.target.value
+    };
+    return changedArray;
+  });
+};

--- a/src/utils/resume/makeResumePdf.ts
+++ b/src/utils/resume/makeResumePdf.ts
@@ -1,10 +1,87 @@
 import { jsPDF } from 'jspdf';
+import { convertImgToBase64 } from './convertImgToBase64';
+import { EducationType, ExperienceType, LicenseType } from '@/type/resumeTypes';
 
-// Default export is a4 paper, portrait, using millimeters for units
-export const makeResumePdf = () => {
+export const makeResumePdf = async (
+  profileImg: File | undefined,
+  name: string | number,
+  phoneNum: string | number,
+  email: string | number,
+  expArray: ExperienceType[],
+  eduArray: EducationType[],
+  licArray: LicenseType[]
+) => {
   const doc = new jsPDF();
+  doc.setFont('malgun');
 
-  doc.text('Hello world!', 10, 10);
-  doc.line(15, 19, 195, 19);
-  doc.save('a4.pdf');
+  // 이미지가 있을 때 Base64로 변환
+  if (profileImg) {
+    const imageBase64: string = (await convertImgToBase64(profileImg)) as string;
+    doc.addImage(imageBase64, 'PNG', 150, 20, 30, 40); // x=150, y=10, width=40, height=40
+  }
+
+  // 이름, 직무, 연락처 등 기본 정보 추가
+  doc.setFontSize(20);
+  doc.text(`${name}`, 20, 30); // 이름
+
+  doc.setFontSize(12);
+  doc.text(`Front End`, 20, 40); // 직무
+  doc.text(`연락처: ${phoneNum} | 이메일: ${email}`, 20, 50); // 연락처
+
+  let yPosition = 65;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.height;
+  const addNewPageIfNecessary = () => {
+    if (yPosition > pageHeight - margin) {
+      doc.addPage();
+      yPosition = 20; // 새 페이지의 시작 위치
+    }
+  };
+
+  // 경력 섹션
+  doc.setFontSize(16);
+  !!expArray.length && doc.text('경력', 20, yPosition); // 섹션 제목
+
+  yPosition += 10;
+  doc.setFontSize(12);
+  expArray.forEach((exp) => {
+    addNewPageIfNecessary();
+    doc.text(`${exp.exp_region} | ${exp.exp_position}`, 20, yPosition); // 회사명 및 직위
+    doc.text(`${exp.exp_period}`, 150, yPosition); // 기간
+
+    yPosition += 10;
+    doc.text(`${exp.exp_desc}`, 20, yPosition); // 상세 설명
+
+    yPosition += 15;
+  });
+
+  // 학력 섹션
+  yPosition += 10;
+  doc.setFontSize(16);
+  !!eduArray.length && doc.text('학력', 20, yPosition); // 섹션 제목
+
+  yPosition += 10;
+  eduArray.forEach((edu) => {
+    addNewPageIfNecessary();
+    doc.text(`${edu.school_name} | ${edu.major}`, 20, yPosition); // 학교명 및 전공
+    doc.text(`${edu.graduated_at}`, 150, yPosition); // 졸업일자
+
+    yPosition += 15;
+  });
+
+  // 자격증 섹션
+  yPosition += 10;
+  doc.setFontSize(16);
+  !!licArray.length && doc.text('자격증 / 면허증', 20, yPosition); // 섹션 제목
+
+  yPosition += 10;
+  licArray.forEach((lic) => {
+    addNewPageIfNecessary();
+    doc.text(`${lic.lic_title} | ${lic.lic_agency}`, 20, yPosition); // 자격증명 및 발급기관
+    doc.text(`${lic.lic_date}`, 150, yPosition); // 자격증 취득일
+
+    yPosition += 15;
+  });
+
+  return doc;
 };

--- a/src/utils/resume/server-action.ts
+++ b/src/utils/resume/server-action.ts
@@ -1,0 +1,51 @@
+'use server';
+
+import { ResumeFormType } from '@/type/resumeTypes';
+import browserClient from '../supabase/client';
+
+const getPostDetail = async (query_post_id: string) => {
+  const { data, error } = await browserClient
+    .from('post_detail')
+    .select(
+      'post_id,isadopted,experience,region,post_title,post_desc,name,gender,phoneNum,email,address, eduArray:post_detail_education(*), expArray:post_detail_experience(*), licArray:post_detail_license(*)'
+    )
+    .eq('post_id', query_post_id);
+  return { data, error };
+};
+
+const uploadResumeData = async (resumeFormData: ResumeFormType) => {
+  const { data, error } = await browserClient.from('post_detail').insert([resumeFormData]);
+  return { data, error };
+};
+
+const updateResumeData = async (query_post_id: string, resumeFormData: ResumeFormType) => {
+  const { data, error } = await browserClient.from('post_detail').update([resumeFormData]).eq('post_id', query_post_id);
+  return { data, error };
+};
+
+const uploadTransformedData = async <T>(eduFormData: T, tableName: string) => {
+  const { data, error } = await browserClient.from(tableName).insert([eduFormData]);
+  return { data, error };
+};
+
+const updateTransformedData = async <T, K extends keyof T>(transformedFormData: T, tableName: string, equalWith: K) => {
+  const { data, error } = await browserClient
+    .from(tableName)
+    .update([transformedFormData])
+    .eq(equalWith as string, transformedFormData[equalWith]);
+  return { data, error };
+};
+
+const getUserPoint = async (userId: string) => {
+  const { data, error } = await browserClient.from('point').select('user_point').eq('user_id', userId);
+  return { data, error };
+};
+
+export {
+  getPostDetail,
+  updateResumeData,
+  uploadResumeData,
+  uploadTransformedData,
+  updateTransformedData,
+  getUserPoint
+};


### PR DESCRIPTION
- pdf생성중 페이지가 넘어갈 시 다음페이지 생성 후 이어서 작성하도록 변경

## ✅ 작업 사항

- resumeadd페이지 컴포넌트 분리
![image](https://github.com/user-attachments/assets/5dce642c-c682-4e1d-a539-a5b5e7e34c85)

- resumeadd페이지 로직 분리
![image](https://github.com/user-attachments/assets/3499f1fb-8f2a-4a0c-81b2-581bd54b22e6)
 - 조금 기괴한 모양이긴 하나 어떻게 더 리팩토링해야할지 생각이 안나 내버려둠

- resumeadd관련 fetch요청 client-action, server-action분리
 - PDF파일을 넘겨줘야하는 로직은 base64관련 작업이 필요하여 client-action으로 사용함
- 서버 액션
![image](https://github.com/user-attachments/assets/de1cf26a-9c2b-48d3-8dc5-9371a6753f86)

- 클라이언트 액션
![image](https://github.com/user-attachments/assets/156ff0c3-4e2a-421d-a323-b7db8d70fde7)


## 📌 변경 사항

- pdf생성도중 페이지를 넘길 시 다음 페이지 생성하여 데이터 이어붙이도록 수정
![image](https://github.com/user-attachments/assets/2bd0a809-b165-494b-b83f-7b2f64696233)
 - 데이터가 끊길 위험이 있는 경력-학력-자격 관련 로직에만 검사하도록 구현함
## 🧑‍💻 기타

-
-